### PR TITLE
Change configuration directory name to 'elogviewer'

### DIFF
--- a/elogviewer.py
+++ b/elogviewer.py
@@ -554,7 +554,7 @@ class Elogviewer(ElogviewerUi):
     def __init__(self, config):
         super(Elogviewer, self).__init__()
         self.config = config
-        self.settings = QtCore.QSettings("Mathias Laurin", "elogviewer")
+        self.settings = QtCore.QSettings("elogviewer", "elogviewer")
         if not self.settings.contains("readFlag"):
             self.settings.setValue("readFlag", set())
         if not self.settings.contains("importantFlag"):


### PR DESCRIPTION
Pull request to change configuration directory name as previously discussed.

You may want to put some info messages into the ebuild announcing the change so users can migrate their old config when updating.