### PR TITLE
Improve triggers, differentiate push and PR

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -3,13 +3,11 @@ name: ansible-test
 
 on:
   push:
+    branches: [main]
     paths:
       - 'vm/**'
       - 'uv.lock'
   pull_request:
-    paths:
-      - 'vm/**'
-      - 'uv.lock'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,7 @@ name: e2e
 
 on:
   push:
+    branches: [main]
     paths:
       - 'vm/**'
       - 'uv.lock'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,11 @@
 ---
 name: lint
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
 
 env:
   PYTHON_VERSION: '3.13'

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -3,15 +3,8 @@ name: python-test
 
 on:
   push:
-    paths:
-      - '**/*.py'
-      - 'pyproject.toml'
-      - 'uv.lock'
+    branches: [main]
   pull_request:
-    paths:
-      - '**/*.py'
-      - 'pyproject.toml'
-      - 'uv.lock'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
 * limit e2e test to push on the default branch
 * run all other tests on pull request to simplify branch protection
 * keep paths only on push to simplify branch protection