### PR TITLE
ci: Group dependabot PRs + add GH ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,16 @@ updates:
     directory: /
     schedule:
       interval: monthly
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
+    groups:
+      all-dependencies:
+        update-types: [minor, patch]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    groups:
+      all-dependencies:
+        update-types: [minor, patch]


### PR DESCRIPTION
 * dependabot already merged ~3 PRs today, that's too much noise, let's group PRs there.
 * Add GH ecosystem to monitor the version of the actions' workflows.