### PR TITLE
ci: Add "summary jobs" to ease branch protection

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -31,3 +31,13 @@ jobs:
         if: always()
         with:
           report_paths: vm/roles/gentoo_base/junit/*.xml
+
+  all-checks:
+    if: ${{ !cancelled() }}
+    needs: [ansible-test]
+    runs-on: ubuntu-latest
+    steps:
+      - if: >-
+          ${{ contains(needs.*.result, 'failure')
+          || contains(needs.*.result, 'cancelled') }}
+        run: exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,3 +72,13 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Run yamllint
         run: uv run --extra lint yamllint -f github .
+
+  all-checks:
+    if: ${{ !cancelled() }}
+    needs: [ansible-lint, ruff-format, ruff-lint, yamllint]
+    runs-on: ubuntu-latest
+    steps:
+      - if: >-
+          ${{ contains(needs.*.result, 'failure')
+          || contains(needs.*.result, 'cancelled') }}
+        run: exit 1

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -48,3 +48,13 @@ jobs:
         if: always()
         with:
           report_paths: pytest.xml
+
+  all-checks:
+    if: ${{ !cancelled() }}
+    needs: [ty, pytest]
+    runs-on: ubuntu-latest
+    steps:
+      - if: >-
+          ${{ contains(needs.*.result, 'failure')
+          || contains(needs.*.result, 'cancelled') }}
+        run: exit 1


### PR DESCRIPTION
It's difficult to find the jobs required for branch protection in the GitHub UI without those.

https://oneuptime.com/blog/post/2026-01-26-status-checks-github-actions/view