### PR TITLE
ci: Make pre-commit the single source of truth for linters

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ env:
   PYTHON_VERSION: '3.13'
 
 jobs:
-  ansible-lint:
+  pre-commit:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -23,14 +23,8 @@ jobs:
       - uses: ./.github/actions/setup-ansible
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - name: Run ansible-lint
-        run: uv run --extra lint ansible-lint --sarif-file ansible-lint.sarif
-      - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v4
-        if: ${{ !cancelled() }}
-        with:
-          sarif_file: ansible-lint.sarif
-          category: ansible-lint
+      - name: Run pre-commit
+        run: uv run --all-extras pre-commit run --all-files
 
   check-wheel-contents:
     runs-on: ubuntu-latest
@@ -48,77 +42,11 @@ jobs:
           uv build --wheel
           && uv run --extra lint check-wheel-contents dist/
 
-  ruff-format:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/setup-python
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Run ruff format
-        run: >-
-          uv run --extra lint
-          ruff format --check --output-format github
-
-  ruff-lint:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/setup-python
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Run ruff check
-        run: >-
-          uv run --extra lint
-          ruff check --output-format github
-
-  ty:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/setup-python
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Run ty
-        run: >-
-          uv run --extra lint --extra test
-          ty check --output-format github
-
-  yamllint:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/setup-python
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Run yamllint
-        run: uv run --extra lint yamllint -f github .
-
   all-checks:
     if: ${{ !cancelled() }}
     needs:
-      - ansible-lint
+      - pre-commit
       - check-wheel-contents
-      - ruff-format
-      - ruff-lint
-      - ty
-      - yamllint
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,12 +9,19 @@ repos:
         args: [--unsafe]  # allow custom YAML tags used by Ansible
 
   - repo: https://github.com/instrumentl/pre-commit-just
-    rev: 'main'
+    rev: 'v0.1'
     hooks:
       - id: format-justfile
 
   - repo: local
     hooks:
+      - id: just-fmt
+        name: just --fmt
+        entry: uv run --extra just just --fmt --unstable
+        language: unsupported
+        files: ^justfile$
+        pass_filenames: false
+
       - id: ruff-format
         name: ruff format
         entry: uv run --extra lint ruff format --check
@@ -22,8 +29,14 @@ repos:
         types: [python]
 
       - id: ruff
-        name: ruff lint
+        name: ruff check
         entry: uv run --extra lint ruff check
+        language: unsupported
+        types: [python]
+
+      - id: ruff-isort
+        name: ruff check-isort
+        entry: uv run --extra lint ruff check --select I
         language: unsupported
         types: [python]
 

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@
 _just := just_executable()
 
 default:
-    just --list
+    @just --list
 
 doc:
     mkdir -p html
@@ -11,17 +11,24 @@ doc:
 upload-doc: doc
     rsync -avzP -e ssh html/ mathias_laurin@web.sourceforge.net:/home/project-web/elogviewer/htdocs/
 
-format:
-    uv run ruff format
-
 lint:
-    uv run ruff check --select I --fix
-    uv run ruff check --fix
+    uv run pre-commit run
+
+lint-all:
+    uv run pre-commit run --all-files
+
+update-linters:
+    uv run pre-commit autoupdate
+
+update-dependencies:
+    uv sync
+
+update: update-linters update-dependencies
 
 test:
     uv run pytest
 
-qa: format lint test
+qa: lint test
 
 _build-path type:
     @uv build --{{ type }} 2>&1 | perl -ne 'print $1 if /Successfully built\s+(.+)/'


### PR DESCRIPTION
Architecture

 * uv declares and pins the linters
 * pre-commit runs them
 * CI runs pre-commit