### PR TITLE
ci: re-organize deps

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,19 +2,19 @@ alias_dir=$(direnv_layout_dir)/aliases
 mkdir -p "$alias_dir"
 
 make_alias() {
-    printf '#!/bin/sh\nuv run --extra %s %s "$@"\n' "$1" "$2" > "$alias_dir/$2"
+    printf '#!/bin/sh\nuv run --group %s %s "$@"\n' "$1" "$2" > "$alias_dir/$2"
     chmod +x "$alias_dir/$2"
 }
 
 make_alias vm      ansible
 make_alias vm      ansible-lint
-make_alias just    just
+make_alias dev     just
 make_alias vm      molecule
-make_alias lint    pre-commit
-make_alias test    pytest
-make_alias lint    ruff
-make_alias lint    ty
-make_alias lint    yamllint
-make_alias lint    zizmor
+make_alias dev     pre-commit
+make_alias dev     pytest
+make_alias dev     ruff
+make_alias dev     ty
+make_alias vm      yamllint
+make_alias dev     zizmor
 
 PATH_add "$alias_dir"

--- a/.github/actions/setup-ansible/action.yml
+++ b/.github/actions/setup-ansible/action.yml
@@ -20,5 +20,5 @@ runs:
     - name: Install ansible collections
       shell: bash
       run: >-
-        uv run --extra vm
+        uv run --group vm
         ansible-galaxy collection install ansible.posix community.general

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -29,11 +29,11 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Test gentoo_base
         id: test_base
-        run: cd roles/gentoo_base && uv run --extra vm molecule test
+        run: cd roles/gentoo_base && uv run --group vm molecule test
         continue-on-error: true
       - name: Test gentoo_system
         id: test_system
-        run: cd roles/gentoo_system && uv run --extra vm molecule test
+        run: cd roles/gentoo_system && uv run --group vm molecule test
         continue-on-error: true
       - name: Publish test results
         uses: mikepenz/action-junit-report@v6

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,7 +39,7 @@ jobs:
           key: gentoo-e2e-${{ github.run_id }}
           restore-keys: gentoo-e2e-
       - name: Run e2e scenario
-        run: uv run --extra vm molecule test --scenario-name e2e
+        run: uv run --group vm molecule test --scenario-name e2e
       - name: Save cache
         uses: actions/cache/save@v5
         if: ${{ !cancelled() }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Run pre-commit
-        run: uv run --all-extras pre-commit run --all-files
+        run: uv run --all-groups pre-commit run --all-files
 
   check-wheel-contents:
     runs-on: ubuntu-latest
@@ -40,7 +40,7 @@ jobs:
       - name: Run check-wheel-contents
         run: >-
           uv build --wheel
-          && uv run --extra lint check-wheel-contents dist/
+          && uv run --group dev check-wheel-contents dist/
 
   all-checks:
     if: ${{ !cancelled() }}

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           PYTHONPATH: .
           QT_QPA_PLATFORM: offscreen
-        run: uv run --extra test pytest --junit-xml=pytest.xml
+        run: uv run --group dev pytest --junit-xml=pytest.xml
       - name: Publish pytest results
         uses: mikepenz/action-junit-report@v6
         if: ${{ !cancelled() }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,60 +8,55 @@ repos:
       - id: check-yaml
         args: [--unsafe]  # allow custom YAML tags used by Ansible
 
-  - repo: https://github.com/instrumentl/pre-commit-just
-    rev: 'v0.1'
-    hooks:
-      - id: format-justfile
-
   - repo: local
     hooks:
       - id: just-fmt
         name: just --fmt
-        entry: uv run --extra just just --fmt --unstable
+        entry: uv run --group dev just --fmt --unstable
         language: unsupported
         files: ^justfile$
         pass_filenames: false
 
       - id: ruff-format
         name: ruff format
-        entry: uv run --extra lint ruff format --check
+        entry: uv run --group dev ruff format --check
         language: unsupported
         types: [python]
 
       - id: ruff
         name: ruff check
-        entry: uv run --extra lint ruff check
+        entry: uv run --group dev ruff check
         language: unsupported
         types: [python]
 
       - id: ruff-isort
         name: ruff check-isort
-        entry: uv run --extra lint ruff check --select I
+        entry: uv run --group dev ruff check --select I
         language: unsupported
         types: [python]
 
       - id: ty
         name: ty check
-        entry: uv run --extra lint --extra test ty check
+        entry: uv run --group dev ty check
         language: unsupported
         types: [python]
 
       - id: yamllint
         name: yamllint
-        entry: uv run --extra lint yamllint
+        entry: uv run --group vm yamllint
         language: unsupported
         types: [yaml]
 
       - id: ansible-lint
         name: ansible-lint
-        entry: uv run --extra lint ansible-lint .
+        entry: uv run --group vm ansible-lint .
         language: unsupported
         files: ^(roles|molecule|inventory)/
         pass_filenames: false
 
       - id: zizmor
         name: zizmor
-        entry: zizmor .github
+        entry: uv run --group dev zizmor .github
         language: unsupported
         types: [yaml]
         files: ^.github/

--- a/justfile
+++ b/justfile
@@ -40,20 +40,20 @@ _build-path type:
     tar --list -f $({{ _just }} _build-path sdist)
 
 vm-test:
-    cd roles/gentoo_base && uv run --extra vm molecule test
-    cd roles/gentoo_system && uv run --extra vm molecule test
+    cd roles/gentoo_base && uv run --group vm molecule test
+    cd roles/gentoo_system && uv run --group vm molecule test
 
 e2e:
-    uv run --extra vm molecule test --scenario-name e2e
+    uv run --group vm molecule test --scenario-name e2e
 
 vm-start:
-    uv run --extra vm vagrant --provision up
+    uv run --group vm vagrant --provision up
 
 vm-stop:
-    uv run --extra vm vagrant halt
+    uv run --group vm vagrant halt
 
 vm-provision: vm-start
-    uv run --extra vm vagrant provision
+    uv run --group vm vagrant provision
 
 vm-deploy: vm-start
     uv build --wheel
@@ -63,7 +63,7 @@ vm-reboot: vm-start
     ansible -i inventory gentoo -m ansible.builtin.reboot -b
 
 vm-destroy:
-    uv run --extra vm vagrant -f destroy
+    uv run --group vm vagrant -f destroy
 
 vm-ssh: vm-start
     vagrant ssh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,19 +22,20 @@ classifiers = [
     "Environment :: X11 Applications :: Qt",
 ]
 
-[project.optional-dependencies]
-just = ["rust-just"]
-lint = [
-    "ansible-lint",
+[dependency-groups]
+dev = [
     "check-wheel-contents",
+    "pyfakefs",
     "pre-commit",
+    "pytest",
+    "pytest-qt",
+    "pyqt6-stubs>=20250824",
     "ruff",
+    "rust-just",
     "ty",
-    "yamllint",
     "zizmor",
 ]
-test = ["pyfakefs", "pytest", "pytest-qt"]
-vm = ["ansible", "molecule", "molecule-docker", "passlib"]
+vm = ["ansible", "ansible-lint", "molecule", "molecule-docker", "passlib", "yamllint"]
 
 [tool.check-artefacts]
 required = ["elogviewer.1", "README.md", "LICENSE.TXT", "py.typed"]
@@ -57,9 +58,4 @@ include = [
     "/src/elogviewer/",
     "/tests/",
     "README.md",
-]
-
-[dependency-groups]
-dev = [
-    "pyqt6-stubs>=20250824",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -419,60 +419,55 @@ dependencies = [
     { name = "pyqt6" },
 ]
 
-[package.optional-dependencies]
-just = [
-    { name = "rust-just" },
-]
-lint = [
-    { name = "ansible-lint" },
+[package.dev-dependencies]
+dev = [
     { name = "check-wheel-contents" },
     { name = "pre-commit" },
-    { name = "ruff" },
-    { name = "ty" },
-    { name = "yamllint" },
-    { name = "zizmor" },
-]
-test = [
     { name = "pyfakefs" },
+    { name = "pyqt6-stubs" },
     { name = "pytest" },
     { name = "pytest-qt" },
+    { name = "ruff" },
+    { name = "rust-just" },
+    { name = "ty" },
+    { name = "zizmor" },
 ]
 vm = [
     { name = "ansible" },
+    { name = "ansible-lint" },
     { name = "molecule" },
     { name = "molecule-docker" },
     { name = "passlib" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pyqt6-stubs" },
+    { name = "yamllint" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "ansible", marker = "extra == 'vm'" },
-    { name = "ansible-lint", marker = "extra == 'lint'" },
-    { name = "check-wheel-contents", marker = "extra == 'lint'" },
-    { name = "molecule", marker = "extra == 'vm'" },
-    { name = "molecule-docker", marker = "extra == 'vm'" },
-    { name = "passlib", marker = "extra == 'vm'" },
     { name = "portage" },
-    { name = "pre-commit", marker = "extra == 'lint'" },
-    { name = "pyfakefs", marker = "extra == 'test'" },
     { name = "pyqt6" },
-    { name = "pytest", marker = "extra == 'test'" },
-    { name = "pytest-qt", marker = "extra == 'test'" },
-    { name = "ruff", marker = "extra == 'lint'" },
-    { name = "rust-just", marker = "extra == 'just'" },
-    { name = "ty", marker = "extra == 'lint'" },
-    { name = "yamllint", marker = "extra == 'lint'" },
-    { name = "zizmor", marker = "extra == 'lint'" },
 ]
-provides-extras = ["just", "lint", "test", "vm"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pyqt6-stubs", specifier = ">=20250824" }]
+dev = [
+    { name = "check-wheel-contents" },
+    { name = "pre-commit" },
+    { name = "pyfakefs" },
+    { name = "pyqt6-stubs", specifier = ">=20250824" },
+    { name = "pytest" },
+    { name = "pytest-qt" },
+    { name = "ruff" },
+    { name = "rust-just" },
+    { name = "ty" },
+    { name = "zizmor" },
+]
+vm = [
+    { name = "ansible" },
+    { name = "ansible-lint" },
+    { name = "molecule" },
+    { name = "molecule-docker" },
+    { name = "passlib" },
+    { name = "yamllint" },
+]
 
 [[package]]
 name = "enrich"
@@ -1285,24 +1280,24 @@ wheels = [
 
 [[package]]
 name = "rust-just"
-version = "1.48.1"
+version = "1.49.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bd/45/79cf9de9dabfaac15ae9defbef6c82f46bdf1750365bc474fa75b9ead928/rust_just-1.48.1.tar.gz", hash = "sha256:57d7cb0be4147bdfe695a77472befae6d605d85076211fa4d8d33287ad075d53", size = 1897010, upload-time = "2026-03-28T02:43:31.518Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/f2/c1612952bb4de508e89a1a10ff8bc7fbf18160bf75bcf502264e04e0c3ba/rust_just-1.49.0.tar.gz", hash = "sha256:a3b5f16f5e131b7ea86720510798688c146ae4859a92410e1ed5d13e79ddcd0f", size = 1912238, upload-time = "2026-04-09T05:38:11.349Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/b8/7ac4eb63363cb75e5712d0c5ebeb18aec54d4350a8cf7cee52de3afa2b17/rust_just-1.48.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:26bbced9640510892b732c8258794521975dce29558d2ebb802fb1fa9476ba72", size = 1845002, upload-time = "2026-03-28T02:42:51.45Z" },
-    { url = "https://files.pythonhosted.org/packages/09/84/475ae8204f126fb1e8566720eb54c8774d90884523322ec5a0ed98b797fd/rust_just-1.48.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1d4ca64ec3f1658ce13613df7a835c3bcbcd742c8c7bee388ccc3d82692deae5", size = 1719020, upload-time = "2026-03-28T02:42:54.506Z" },
-    { url = "https://files.pythonhosted.org/packages/44/92/fee67da8b8640bfa5a4a1e590f05ed2900216b08091156ce91dc41c49e7d/rust_just-1.48.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40320cc843a1f7a4c07c78cd4c613cb7bb4ad3a0a1d659aa822c5d6736eff402", size = 1801138, upload-time = "2026-03-28T02:42:57.115Z" },
-    { url = "https://files.pythonhosted.org/packages/83/4f/5b18aeca27909b179c3631ebe42a4f546c7ccc5ec3e14aa342d86fbe8aef/rust_just-1.48.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5a8964d52445b7e9138f4145d2ee562de4d8b0c2de7d92da22c7fc48cb4412a3", size = 1766412, upload-time = "2026-03-28T02:42:59.778Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/ad/466f0eff38b7917f8a0003da335bf5e9c1d28ea4a8267eef9ab465fe64f2/rust_just-1.48.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:14f4259a22d29d998bfaeb4b0bc30bce4434289010ec09fa1830492c1a4bc5e2", size = 1969657, upload-time = "2026-03-28T02:43:02.728Z" },
-    { url = "https://files.pythonhosted.org/packages/19/a3/965d2fe09b5e36bd2953ee366f1ba9651a12790423a0c575d59e2dc8a3b8/rust_just-1.48.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8fc8e2e801ab7a9098c672acb79e4feb9ebaddb4c98ebba427a95cd520dba43c", size = 2034263, upload-time = "2026-03-28T02:43:06.012Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/f1/bc591f56d3536bf4c5639e3b13ade00caf50ec935078f40872ab23be04c2/rust_just-1.48.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2c2e56ccab88a66ce2b76fb22f69218e106823ab12c0f9e949a2a9721c9e97c9", size = 2012112, upload-time = "2026-03-28T02:43:08.897Z" },
-    { url = "https://files.pythonhosted.org/packages/25/02/1e083d9f6247284b925fe7caa93c4e4f6a738189862e8f060cb17a4d5325/rust_just-1.48.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e98ef5cb299a7697334842b37504925fc4a5d8f4c8c86c6f8bf37ca876a88f4", size = 1953061, upload-time = "2026-03-28T02:43:11.994Z" },
-    { url = "https://files.pythonhosted.org/packages/65/e9/e3b284f18428d04cf251da1cfc15d7f4f00a71f04ff154743e157774ec49/rust_just-1.48.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5216dd785e38e395402c90c82c0c812201eb45801eb89a68f46a194be5b10ee0", size = 1826984, upload-time = "2026-03-28T02:43:14.965Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/ce/0456e8c9b9e97685922280b130282ff841e70a440617a4604066e6c3ae82/rust_just-1.48.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ea2a7744ed0e3d506472609a66bd453396cd55decf599202789fc49a312f22b5", size = 1794852, upload-time = "2026-03-28T02:43:17.832Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/97/cdebd7b72b0255b8c1da41b35d83b68cf5f5139b265f8f265e4749b94d25/rust_just-1.48.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ab8aa14cd47f605174a411bbb0a1788f98761958bd26abdf71625f4402b9cc4a", size = 1955082, upload-time = "2026-03-28T02:43:20.407Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/01/f93a79b5a0be94350768dabbbb7250f6d20c2f08287a38dae54c6031e93f/rust_just-1.48.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06e8e478afce514c14c77daefe7b3a4e1acec54a28d6e2e94ab0ffd2ac048de0", size = 2019002, upload-time = "2026-03-28T02:43:23.138Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/58/665cfe84e1f5ee49f330273b0aa69782a213bd40dc1de39a57191eb63199/rust_just-1.48.1-py3-none-win32.whl", hash = "sha256:8c13af3168ae58e3c08d55f0e1c7004edfcfb8d27dd2004d784d1f98986f354e", size = 1741535, upload-time = "2026-03-28T02:43:25.772Z" },
-    { url = "https://files.pythonhosted.org/packages/61/17/d6f6c5d35c311aeff942837a2c5cc39558efdb78bebde0217bbb90469e97/rust_just-1.48.1-py3-none-win_amd64.whl", hash = "sha256:3670048504027fe9288820de661dfaf89af0a4505191fa8a92a242436e86d5f9", size = 1928505, upload-time = "2026-03-28T02:43:28.556Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d9/5f7fa48d2903345a885a4d93a5c3a75d14acad8211a6e41bc24c6221f479/rust_just-1.49.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c91cad7bbb9280b74f0f6761b4b9f91ab8b30e6fd29885d463fcee011c1c28a8", size = 1976290, upload-time = "2026-04-09T05:38:09.916Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/2a/bcac6a5091dbbdac5536a28f5c5747a7ce4d251e2273a2586a03b6e15fd1/rust_just-1.49.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:655b50c40a6a43464a3b217874d81623143c95fecfcaca476d5552d3cdb035b3", size = 1839665, upload-time = "2026-04-09T05:38:20.522Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/ec/8dff9bcc9327cea9990e0c88932e554131afcf4b593e5163de1c994bd325/rust_just-1.49.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4cd8b7a1d7a84f95ebba73a2038eed1d89e2ae397f80e89c99a25e34808206f8", size = 1927171, upload-time = "2026-04-09T05:38:15.779Z" },
+    { url = "https://files.pythonhosted.org/packages/93/a1/d7cc40ec13a702f1fecc4f14d5d6e34f31e557a8cf4e14fd4de0e364d9eb/rust_just-1.49.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:505f7d9c132f8ba747b35c7ba92c5bca13950875b4040a4c0c1a5aa1b94bc3f6", size = 1904953, upload-time = "2026-04-09T05:38:12.779Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/0f/19be2e9f6682ae4941b4ea98cefa9c6f3f41ca32f134407651fdc52c38c9/rust_just-1.49.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e82381559658f83c5888a36f420b4bec6e4abdecef7ad40d4c74a90d80551e96", size = 2108508, upload-time = "2026-04-09T05:37:59.591Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7f/d073eaf6729e4c239c9935bd1a94ea19e9dd9504242e077d651e41fdb386/rust_just-1.49.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b3dd978725e4ed8d34d0518acf34e6cd9e215bb24737b62eed87fec3d4747507", size = 2177355, upload-time = "2026-04-09T05:38:01.573Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/69/d0331a382c8c6a5390164c591dba4ca74e31c903389fc92dea895654ee67/rust_just-1.49.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ad50c7d05fedc4d87abd6cc44127e1ddc246be56f5f11fad05ac00e0b66c33e4", size = 2120914, upload-time = "2026-04-09T05:38:19.023Z" },
+    { url = "https://files.pythonhosted.org/packages/25/f4/997605402b8502f7637875c1159a6dd9c0dd74d0493d49cf858ea5463b6a/rust_just-1.49.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b2e0f03694f030f3f39f7bba53545d6038eddb87fa0a3383cd9f3a55dcf4ed26", size = 2090756, upload-time = "2026-04-09T05:37:57.931Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/bc/bd90073c7f2725eeef93a9816c8c2d49410339d1863d385071b7960677e5/rust_just-1.49.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d105edbcc02e278fa3eb6730a8be2c4576e5ce4f52f43706ae5e7a07af112278", size = 1949099, upload-time = "2026-04-09T05:38:17.346Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/54/cf57ec444c1fa851525d651f67f7eb4c1b52e701568638d2784fe690fd62/rust_just-1.49.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6bc0c84f1c1bc5c13b66f6947e21e7828f0df0048cff40565ed7b574e04cfd16", size = 1931798, upload-time = "2026-04-09T05:38:14.114Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/a3/7a5ec8e401f4b069d6577c8cc72592264ec220eabd0e767db7aad22a6586/rust_just-1.49.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:abe84305fc4591c95f4dc0a02f61228a4bf64a4a5d5558cbf4777401147f9681", size = 2080900, upload-time = "2026-04-09T05:38:03.31Z" },
+    { url = "https://files.pythonhosted.org/packages/98/65/817e047a93e0d9c4faa5eb9de05db4f1631f419f5dccc94a4e16dda79309/rust_just-1.49.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a814fccd210727d587ba058efb2c54e772a102a73bc729759cf96667d1d4f599", size = 2155307, upload-time = "2026-04-09T05:38:05.214Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/e0/e7678714597383cf9ccd76ed7819b1cf6e3d079c80bdf476496634be36de/rust_just-1.49.0-py3-none-win32.whl", hash = "sha256:9ace425355867b3249b9c61ed7c23a2f482259345de3e649c262deb1263c321d", size = 1855815, upload-time = "2026-04-09T05:38:06.595Z" },
+    { url = "https://files.pythonhosted.org/packages/08/85/ce1299f161ea7094c175953d1cb17aaf19900e9ec23edfbe728b27cd2cbd/rust_just-1.49.0-py3-none-win_amd64.whl", hash = "sha256:e34a1845394d947f2f7e47ba8c9fe9d323bb6c21af4aa5dca5168507ecdb7eba", size = 2064187, upload-time = "2026-04-09T05:38:08.316Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
 * extra -> group:  We don't want to publish the dev deps
 * reduce the number of namespaces: regular, dev, and vm
 * move vm-only deps to the vm group