### PR TITLE
vm: disable `debuginfod`

### DIFF
--- a/roles/gentoo_base/templates/make_conf_base.j2
+++ b/roles/gentoo_base/templates/make_conf_base.j2
@@ -22,4 +22,4 @@ EMERGE_DEFAULT_OPTS="${EMERGE_DEFAULT_OPTS} --quiet"
 EMERGE_DEFAULT_OPTS="${EMERGE_DEFAULT_OPTS} --load-average={{ ncpus }}"
 EMERGE_DEFAULT_OPTS="${EMERGE_DEFAULT_OPTS} --jobs={{ ncpus }}"
 
-USE="${USE} -llvm elogind openssl {{ gentoo_base_qt_use_flag }} unicode X harfbuzz"
+USE="${USE} -debuginfod -llvm elogind openssl {{ gentoo_base_qt_use_flag }} unicode X harfbuzz"


### PR DESCRIPTION
 * not useful in a VM
 * requires masked dependencies